### PR TITLE
Publish Markdown docs to GitHub Pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish Markdown to GitHub Pages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install markdown
+      - name: Build HTML
+        env:
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          python scripts/build_site.py
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Build static HTML files from Markdown sources.
+
+All .md files under the repository are converted to HTML and written under the
+`site` directory preserving the directory structure. Each generated page
+includes an "Edit this page" link pointing back to the source file on the main
+branch of the GitHub repository.
+"""
+
+import os
+from pathlib import Path
+import markdown
+
+REPO_URL = os.environ.get("REPO_URL", "").rstrip("/")
+SOURCE_DIR = Path(".")
+OUTPUT_DIR = Path("site")
+
+for md_path in SOURCE_DIR.rglob("*.md"):
+    if ".git" in md_path.parts:
+        continue
+    rel_path = md_path.relative_to(SOURCE_DIR)
+    html_body = markdown.markdown(md_path.read_text(encoding="utf-8"))
+    edit_url = f"{REPO_URL}/blob/main/{rel_path.as_posix()}" if REPO_URL else ""
+    full_html = f"""<!doctype html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<title>{md_path.stem}</title>
+</head>
+<body>
+{html_body}
+<p><a href=\"{edit_url}\">Edit this page</a></p>
+</body>
+</html>
+"""
+    out_file = OUTPUT_DIR / rel_path.with_suffix(".html")
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    out_file.write_text(full_html, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add release workflow triggered by tags starting with `v*`
- convert markdown files to HTML with edit links and deploy to GitHub Pages

## Testing
- `REPO_URL=https://github.com/example/example python scripts/build_site.py`
- `find site -maxdepth 1 -type f | sort`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689939913fa0832f8ac6a0b426011dde