### PR TITLE
Fix internal markdown links when generating HTML

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -10,6 +10,7 @@ branch of the GitHub repository.
 import os
 from pathlib import Path
 import markdown
+import re
 
 REPO_URL = os.environ.get("REPO_URL", "").rstrip("/")
 SOURCE_DIR = Path(".")
@@ -19,7 +20,13 @@ for md_path in SOURCE_DIR.rglob("*.md"):
     if ".git" in md_path.parts:
         continue
     rel_path = md_path.relative_to(SOURCE_DIR)
-    html_body = markdown.markdown(md_path.read_text(encoding="utf-8"))
+    md_text = md_path.read_text(encoding="utf-8")
+    html_body = markdown.markdown(md_text)
+    html_body = re.sub(
+        r'href="([^":]+)\.md(#[^"]*)?"',
+        r'href="\1.html\2"',
+        html_body,
+    )
     edit_url = f"{REPO_URL}/blob/main/{rel_path.as_posix()}" if REPO_URL else ""
     full_html = f"""<!doctype html>
 <html lang=\"en\">


### PR DESCRIPTION
## Summary
- ensure markdown build script rewrites internal `.md` links to `.html`

## Testing
- `python scripts/build_site.py && ls site | head`


------
https://chatgpt.com/codex/tasks/task_e_68995f68b690832f9f99c00a950adfb8