### PR TITLE
Ignore problematic URLs for lychee link checks

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+https://www.reddit.com/r/FODMAPS/
+https://www.instagram.com/monashfodmap/
+https://www.reddit.com/r/FODMAPS/wiki/index/
+https://www.spoonfulapp.com/
+https://www.instagram.com/erinjudge.rd


### PR DESCRIPTION
## Summary
- add a `.lycheeignore` file to prevent lychee from checking sources that consistently return 403 or 429

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69069f29b34c832f9becc515c19e075d