### PR TITLE
chore: Ignore failing URLs in lychee link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -43,3 +43,10 @@ https://fodshopper.com.au/*
 
 # Continually returning Unknown status code (Added Apr 2026)
 https://www.fodmapformula.com/*
+
+# Returning 403 Forbidden
+https://shecanteatwhat.com/*
+
+# Timed out
+https://rehabproffsen.se/*
+http://rehabproffsen.se/*


### PR DESCRIPTION
This PR adds two domains (`shecanteatwhat.com` and `rehabproffsen.se`) to `.lycheeignore` because they persistently fail the `lychee` link checker with 403 Forbidden and Timeout errors respectively, preventing successful CI/local test runs.

---
*PR created automatically by Jules for task [7875354499178032218](https://jules.google.com/task/7875354499178032218) started by @arran4*